### PR TITLE
feat: support tailwindcss 3

### DIFF
--- a/kitchen-sink/react/pages/Toast.jsx
+++ b/kitchen-sink/react/pages/Toast.jsx
@@ -38,7 +38,7 @@ export default function ToastPage() {
             </Button>
           }
         >
-          <div className="flex-shrink">Hello this is left toast!</div>
+          <div className="shrink">Hello this is left toast!</div>
         </Toast>
         <Toast
           position="center"
@@ -49,7 +49,7 @@ export default function ToastPage() {
             </Button>
           }
         >
-          <div className="flex-shrink">Hello this is center toast!</div>
+          <div className="shrink">Hello this is center toast!</div>
         </Toast>
         <Toast
           position="right"
@@ -60,7 +60,7 @@ export default function ToastPage() {
             </Button>
           }
         >
-          <div className="flex-shrink">Hello this is right toast!</div>
+          <div className="shrink">Hello this is right toast!</div>
         </Toast>
         <p>
           Toasts provide brief feedback about an operation through a message on

--- a/kitchen-sink/vue/pages/Toast.vue
+++ b/kitchen-sink/vue/pages/Toast.vue
@@ -13,7 +13,7 @@
             Close
           </twm-button>
         </template>
-        <div class="flex-shrink">Hello this is left toast!</div>
+        <div class="shrink">Hello this is left toast!</div>
       </twm-toast>
       <twm-toast position="center" :opened="opened.center">
         <template #button>
@@ -21,7 +21,7 @@
             Close
           </twm-button>
         </template>
-        <div class="flex-shrink">Hello this is center toast!</div>
+        <div class="shrink">Hello this is center toast!</div>
       </twm-toast>
       <twm-toast position="right" :opened="opened.right">
         <template #button>
@@ -29,7 +29,7 @@
             Close
           </twm-button>
         </template>
-        <div class="flex-shrink">Hello this is right toast!</div>
+        <div class="shrink">Hello this is right toast!</div>
       </twm-toast>
       <p>
         Toasts provide brief feedback about an operation through a message on

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "tailwind-mobile",
       "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
@@ -39,7 +40,7 @@
         "react-dom": "^17.0.2",
         "react-icons": "^4.2.0",
         "react-router-dom": "^5.2.0",
-        "tailwindcss": "^2.2.7",
+        "tailwindcss": "^3.0.1",
         "vite": "^2.5.1",
         "vue": "^3.2.19",
         "vue-router": "^4.0.11"
@@ -2664,15 +2665,6 @@
         "ieee754": "^1.1.13"
       }
     },
-    "node_modules/bytes": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -2994,16 +2986,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/color": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.3",
-        "color-string": "^1.6.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -3018,16 +3000,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
-    },
-    "node_modules/color-string": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
-      "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "node_modules/colorette": {
       "version": "1.3.0",
@@ -3197,12 +3169,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/css-unit-converter": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz",
-      "integrity": "sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==",
-      "dev": true
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -4937,15 +4903,6 @@
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
     },
-    "node_modules/html-tags": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
-      "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -5360,9 +5317,9 @@
       }
     },
     "node_modules/is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -5736,18 +5693,6 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
-    "node_modules/lodash.toarray": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
-      "dev": true
-    },
-    "node_modules/lodash.topath": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz",
-      "integrity": "sha1-NhY1Hzu6YZlKCTGYlmC9AyVP0Ak=",
-      "dev": true
-    },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
@@ -6057,18 +6002,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/modern-normalize": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/modern-normalize/-/modern-normalize-1.1.0.tgz",
-      "integrity": "sha512-2lMlY1Yc1+CUy0gw4H95uNN7vjbpoED7NNRSBHE25nWfLBdmMzFCsPshlzbxHz+gYMcBEUN8V4pU16prcdPSgA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -6164,15 +6097,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "node_modules/node-emoji": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
-      "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
-      "dev": true,
-      "dependencies": {
-        "lodash.toarray": "^4.4.0"
-      }
     },
     "node_modules/node-releases": {
       "version": "1.1.75",
@@ -6925,28 +6849,28 @@
       }
     },
     "node_modules/postcss-nested": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.5.tgz",
-      "integrity": "sha512-GSRXYz5bccobpTzLQZXOnSOfKl6TwVr5CyAQJUPub4nuRJSOECK5AqurxVgmtxP48p0Kc/ndY/YyS1yqldX0Ew==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.6.tgz",
+      "integrity": "sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==",
       "dev": true,
       "dependencies": {
-        "postcss-selector-parser": "^6.0.4"
+        "postcss-selector-parser": "^6.0.6"
       },
       "engines": {
-        "node": ">=10.0"
+        "node": ">=12.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/postcss/"
       },
       "peerDependencies": {
-        "postcss": "^8.1.13"
+        "postcss": "^8.2.14"
       }
     },
     "node_modules/postcss-selector-parser": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
-      "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.7.tgz",
+      "integrity": "sha512-U+b/Deoi4I/UmE6KOVPpnhS7I7AYdKbhGcat+qTQ27gycvaACvNEw11ba6RrkwVmDVRW7sigWgLj4/KbbJjeDA==",
       "dev": true,
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -6957,9 +6881,9 @@
       }
     },
     "node_modules/postcss-value-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
-      "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
     "node_modules/prelude-ls": {
@@ -6993,15 +6917,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/pretty-hrtime": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/process-nextick-args": {
@@ -7038,30 +6953,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/purgecss": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-4.0.3.tgz",
-      "integrity": "sha512-PYOIn5ibRIP34PBU9zohUcCI09c7drPJJtTDAc0Q6QlRz2/CHQ8ywGLdE7ZhxU2VTqB7p5wkvj5Qcm05Rz3Jmw==",
-      "dev": true,
-      "dependencies": {
-        "commander": "^6.0.0",
-        "glob": "^7.0.0",
-        "postcss": "^8.2.1",
-        "postcss-selector-parser": "^6.0.2"
-      },
-      "bin": {
-        "purgecss": "bin/purgecss.js"
-      }
-    },
-    "node_modules/purgecss/node_modules/commander": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/queue-microtask": {
@@ -7267,22 +7158,6 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
-    },
-    "node_modules/reduce-css-calc": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.8.tgz",
-      "integrity": "sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==",
-      "dev": true,
-      "dependencies": {
-        "css-unit-converter": "^1.1.1",
-        "postcss-value-parser": "^3.3.0"
-      }
-    },
-    "node_modules/reduce-css-calc/node_modules/postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-      "dev": true
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -7708,21 +7583,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-      "dev": true,
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/simple-swizzle/node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
       "dev": true
     },
     "node_modules/slash": {
@@ -8321,40 +8181,30 @@
       "link": true
     },
     "node_modules/tailwindcss": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-2.2.7.tgz",
-      "integrity": "sha512-jv35rugP5j8PpzbXnsria7ZAry7Evh0KtQ4MZqNd+PhF+oIKPwJTVwe/rmfRx9cZw3W7iPZyzBmeoAoNwfJ1yg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.0.1.tgz",
+      "integrity": "sha512-EVDXVZkcueZ77/zfOJw7XkzCuxe5TCiT/S9pw9P183oRzSuwMZ7WO+W/L76jbJQA5qxGeUBJOVOLVBuAUfeZ3g==",
       "dev": true,
       "dependencies": {
-        "arg": "^5.0.0",
-        "bytes": "^3.0.0",
-        "chalk": "^4.1.1",
+        "arg": "^5.0.1",
+        "chalk": "^4.1.2",
         "chokidar": "^3.5.2",
-        "color": "^3.2.0",
-        "cosmiconfig": "^7.0.0",
+        "color-name": "^1.1.4",
+        "cosmiconfig": "^7.0.1",
         "detective": "^5.2.0",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
         "fast-glob": "^3.2.7",
-        "fs-extra": "^10.0.0",
-        "glob-parent": "^6.0.0",
-        "html-tags": "^3.1.0",
-        "is-glob": "^4.0.1",
-        "lodash": "^4.17.21",
-        "lodash.topath": "^4.5.2",
-        "modern-normalize": "^1.1.0",
-        "node-emoji": "^1.8.1",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
         "normalize-path": "^3.0.0",
         "object-hash": "^2.2.0",
         "postcss-js": "^3.0.3",
         "postcss-load-config": "^3.1.0",
-        "postcss-nested": "5.0.5",
+        "postcss-nested": "5.0.6",
         "postcss-selector-parser": "^6.0.6",
-        "postcss-value-parser": "^4.1.0",
-        "pretty-hrtime": "^1.0.3",
-        "purgecss": "^4.0.3",
+        "postcss-value-parser": "^4.2.0",
         "quick-lru": "^5.1.1",
-        "reduce-css-calc": "^2.1.8",
         "resolve": "^1.20.0",
         "tmp": "^0.2.1"
       },
@@ -8420,12 +8270,12 @@
       "dev": true
     },
     "node_modules/tailwindcss/node_modules/glob-parent": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.1.tgz",
-      "integrity": "sha512-kEVjS71mQazDBHKcsq4E9u/vUzaLcw1A8EtUeydawvIWQCJM0qQ08G1H7/XTjFUulla6XQiDOG6MXSaG0HDKog==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "dependencies": {
-        "is-glob": "^4.0.1"
+        "is-glob": "^4.0.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -10944,12 +10794,6 @@
         "ieee754": "^1.1.13"
       }
     },
-    "bytes": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-      "dev": true
-    },
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
@@ -11196,16 +11040,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "color": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-      "dev": true,
-      "requires": {
-        "color-convert": "^1.9.3",
-        "color-string": "^1.6.0"
-      }
-    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -11220,16 +11054,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
-    },
-    "color-string": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.6.0.tgz",
-      "integrity": "sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==",
-      "dev": true,
-      "requires": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "colorette": {
       "version": "1.3.0",
@@ -11361,12 +11185,6 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
-    },
-    "css-unit-converter": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz",
-      "integrity": "sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==",
-      "dev": true
     },
     "cssesc": {
       "version": "3.0.0",
@@ -12665,12 +12483,6 @@
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
     },
-    "html-tags": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
-      "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
-      "dev": true
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -12976,9 +12788,9 @@
       "dev": true
     },
     "is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
@@ -13262,18 +13074,6 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
-    "lodash.toarray": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
-      "dev": true
-    },
-    "lodash.topath": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.topath/-/lodash.topath-4.5.2.tgz",
-      "integrity": "sha1-NhY1Hzu6YZlKCTGYlmC9AyVP0Ak=",
-      "dev": true
-    },
     "lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
@@ -13513,12 +13313,6 @@
         }
       }
     },
-    "modern-normalize": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/modern-normalize/-/modern-normalize-1.1.0.tgz",
-      "integrity": "sha512-2lMlY1Yc1+CUy0gw4H95uNN7vjbpoED7NNRSBHE25nWfLBdmMzFCsPshlzbxHz+gYMcBEUN8V4pU16prcdPSgA==",
-      "dev": true
-    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -13598,15 +13392,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "node-emoji": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
-      "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
-      "dev": true,
-      "requires": {
-        "lodash.toarray": "^4.4.0"
-      }
     },
     "node-releases": {
       "version": "1.1.75",
@@ -14159,18 +13944,18 @@
       }
     },
     "postcss-nested": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.5.tgz",
-      "integrity": "sha512-GSRXYz5bccobpTzLQZXOnSOfKl6TwVr5CyAQJUPub4nuRJSOECK5AqurxVgmtxP48p0Kc/ndY/YyS1yqldX0Ew==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.6.tgz",
+      "integrity": "sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==",
       "dev": true,
       "requires": {
-        "postcss-selector-parser": "^6.0.4"
+        "postcss-selector-parser": "^6.0.6"
       }
     },
     "postcss-selector-parser": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
-      "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.7.tgz",
+      "integrity": "sha512-U+b/Deoi4I/UmE6KOVPpnhS7I7AYdKbhGcat+qTQ27gycvaACvNEw11ba6RrkwVmDVRW7sigWgLj4/KbbJjeDA==",
       "dev": true,
       "requires": {
         "cssesc": "^3.0.0",
@@ -14178,9 +13963,9 @@
       }
     },
     "postcss-value-parser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
-      "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
     "prelude-ls": {
@@ -14203,12 +13988,6 @@
       "requires": {
         "fast-diff": "^1.1.2"
       }
-    },
-    "pretty-hrtime": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
-      "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -14239,26 +14018,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
-    },
-    "purgecss": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-4.0.3.tgz",
-      "integrity": "sha512-PYOIn5ibRIP34PBU9zohUcCI09c7drPJJtTDAc0Q6QlRz2/CHQ8ywGLdE7ZhxU2VTqB7p5wkvj5Qcm05Rz3Jmw==",
-      "dev": true,
-      "requires": {
-        "commander": "^6.0.0",
-        "glob": "^7.0.0",
-        "postcss": "^8.2.1",
-        "postcss-selector-parser": "^6.0.2"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-          "dev": true
-        }
-      }
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -14414,24 +14173,6 @@
           "requires": {
             "safe-buffer": "~5.1.0"
           }
-        }
-      }
-    },
-    "reduce-css-calc": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.8.tgz",
-      "integrity": "sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==",
-      "dev": true,
-      "requires": {
-        "css-unit-converter": "^1.1.1",
-        "postcss-value-parser": "^3.3.0"
-      },
-      "dependencies": {
-        "postcss-value-parser": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-          "dev": true
         }
       }
     },
@@ -14761,23 +14502,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
-    },
-    "simple-swizzle": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "^0.3.1"
-      },
-      "dependencies": {
-        "is-arrayish": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-          "dev": true
-        }
-      }
     },
     "slash": {
       "version": "2.0.0",
@@ -15260,40 +14984,30 @@
       "version": "file:src"
     },
     "tailwindcss": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-2.2.7.tgz",
-      "integrity": "sha512-jv35rugP5j8PpzbXnsria7ZAry7Evh0KtQ4MZqNd+PhF+oIKPwJTVwe/rmfRx9cZw3W7iPZyzBmeoAoNwfJ1yg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.0.1.tgz",
+      "integrity": "sha512-EVDXVZkcueZ77/zfOJw7XkzCuxe5TCiT/S9pw9P183oRzSuwMZ7WO+W/L76jbJQA5qxGeUBJOVOLVBuAUfeZ3g==",
       "dev": true,
       "requires": {
-        "arg": "^5.0.0",
-        "bytes": "^3.0.0",
-        "chalk": "^4.1.1",
+        "arg": "^5.0.1",
+        "chalk": "^4.1.2",
         "chokidar": "^3.5.2",
-        "color": "^3.2.0",
-        "cosmiconfig": "^7.0.0",
+        "color-name": "^1.1.4",
+        "cosmiconfig": "^7.0.1",
         "detective": "^5.2.0",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
         "fast-glob": "^3.2.7",
-        "fs-extra": "^10.0.0",
-        "glob-parent": "^6.0.0",
-        "html-tags": "^3.1.0",
-        "is-glob": "^4.0.1",
-        "lodash": "^4.17.21",
-        "lodash.topath": "^4.5.2",
-        "modern-normalize": "^1.1.0",
-        "node-emoji": "^1.8.1",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
         "normalize-path": "^3.0.0",
         "object-hash": "^2.2.0",
         "postcss-js": "^3.0.3",
         "postcss-load-config": "^3.1.0",
-        "postcss-nested": "5.0.5",
+        "postcss-nested": "5.0.6",
         "postcss-selector-parser": "^6.0.6",
-        "postcss-value-parser": "^4.1.0",
-        "pretty-hrtime": "^1.0.3",
-        "purgecss": "^4.0.3",
+        "postcss-value-parser": "^4.2.0",
         "quick-lru": "^5.1.1",
-        "reduce-css-calc": "^2.1.8",
         "resolve": "^1.20.0",
         "tmp": "^0.2.1"
       },
@@ -15333,12 +15047,12 @@
           "dev": true
         },
         "glob-parent": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.1.tgz",
-          "integrity": "sha512-kEVjS71mQazDBHKcsq4E9u/vUzaLcw1A8EtUeydawvIWQCJM0qQ08G1H7/XTjFUulla6XQiDOG6MXSaG0HDKog==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
           "dev": true,
           "requires": {
-            "is-glob": "^4.0.1"
+            "is-glob": "^4.0.3"
           }
         },
         "has-flag": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react-dom": "^17.0.2",
     "react-icons": "^4.2.0",
     "react-router-dom": "^5.2.0",
-    "tailwindcss": "^2.2.7",
+    "tailwindcss": "^3.0.1",
     "vite": "^2.5.1",
     "vue": "^3.2.19",
     "vue-router": "^4.0.11"

--- a/src/config.js
+++ b/src/config.js
@@ -13,7 +13,7 @@ const pluginTranslucent = require('./config/plugin-translucent.js');
 const pluginRange = require('./config/plugin-range.js');
 const pluginTouch = require('./config/plugin-touch.js');
 
-const purge = `${path.resolve(__dirname)}/**/*.{js,jsx,vue,svelte}`;
+const content = `${path.resolve(__dirname)}/**/*.{js,jsx,vue,svelte}`;
 
 const config = (userConfig = {}) => {
   const newConfig = configExtend(
@@ -37,16 +37,23 @@ const config = (userConfig = {}) => {
     },
     userConfig
   );
-  if (!newConfig.purge) {
-    newConfig.purge = [purge];
-  } else if (Array.isArray(newConfig.purge)) {
-    newConfig.purge = [...newConfig.purge, purge];
-  } else if (newConfig.purge.content) {
-    newConfig.purge.content = [...newConfig.purge.content, purge];
-  } else if (!newConfig.purge.content) {
-    newConfig.purge.content = [purge];
+
+  // support tailwind2 purge config
+  if (newConfig.purge) {
+    if (Array.isArray(newConfig.purge)) {
+      newConfig.content = [...newConfig.purge, content];
+    } else if (newConfig.purge.content) {
+      newConfig.content = [...newConfig.purge.content, content];
+    } else if (!newConfig.purge.content) {
+      newConfig.content = [content];
+    }
   }
 
+  if (!newConfig.content) {
+    newConfig.content = [content];
+  } else if (Array.isArray(newConfig.purge)) {
+    newConfig.content = [...newConfig.purge, content];
+  }
   return newConfig;
 };
 module.exports = config;

--- a/src/config.js
+++ b/src/config.js
@@ -38,23 +38,16 @@ const config = (userConfig = {}) => {
     userConfig
   );
 
-  // support tailwind2 purge config
-  if (newConfig.purge) {
-    if (Array.isArray(newConfig.purge)) {
-      newConfig.content = [...newConfig.purge, content];
-    } else if (newConfig.purge.content) {
-      newConfig.content = [...newConfig.purge.content, content];
-    } else if (!newConfig.purge.content) {
-      newConfig.content = [content];
-    }
-  }
-
   if (!newConfig.content) {
     newConfig.content = [content];
   } else if (Array.isArray(newConfig.content)) {
     newConfig.content = [...newConfig.content, content];
+  } else if (newConfig.content.files) {
+    newConfig.content.files = [...newConfig.content.files, content];
+  } else if (!newConfig.content.files) {
+    newConfig.content.files = [content];
   }
-  console.log(newConfig.content);
+
   return newConfig;
 };
 module.exports = config;

--- a/src/config.js
+++ b/src/config.js
@@ -51,9 +51,10 @@ const config = (userConfig = {}) => {
 
   if (!newConfig.content) {
     newConfig.content = [content];
-  } else if (Array.isArray(newConfig.purge)) {
-    newConfig.content = [...newConfig.purge, content];
+  } else if (Array.isArray(newConfig.content)) {
+    newConfig.content = [...newConfig.content, content];
   }
+  console.log(newConfig.content);
   return newConfig;
 };
 module.exports = config;

--- a/src/react/components/ListInput.jsx
+++ b/src/react/components/ListInput.jsx
@@ -184,7 +184,7 @@ const ListInput = forwardRef((props, ref) => {
           }`
         : '',
       inline: {
-        common: `flex-shrink-10 w-full`,
+        common: `shrink-10 w-full`,
         ios: '-mt-2.5',
         material: `-my-1`,
       },
@@ -203,7 +203,7 @@ const ListInput = forwardRef((props, ref) => {
     },
     titleWrap: {
       material: `duration-200 ${getLabelColor(true)}`,
-      inline: `w-4/12 flex-shrink-0 mr-2`,
+      inline: `w-4/12 shrink-0 mr-2`,
       notInline: '',
     },
     input: {

--- a/src/react/components/ListItem.jsx
+++ b/src/react/components/ListItem.jsx
@@ -146,7 +146,7 @@ const ListItem = forwardRef((props, ref) => {
       },
 
       media: {
-        common: `mr-4 flex-shrink-0 ${mediaClassName}`,
+        common: `mr-4 shrink-0 ${mediaClassName}`,
         ios: 'py-2',
         material: 'py-3 min-w-10',
       },
@@ -165,7 +165,7 @@ const ListItem = forwardRef((props, ref) => {
         material: cls(!menuListItem && titleFontSizeMaterial),
       },
       title: {
-        common: `flex-shrink`,
+        common: `shrink`,
         menuListItem: cls(
           'text-sm',
           strongTitle === true || autoStrongTitle
@@ -180,10 +180,10 @@ const ListItem = forwardRef((props, ref) => {
       },
       after: cls(
         textColor,
-        `text-opacity-55 flex-shrink-0 ml-auto pl-1 flex items-center space-x-1`,
+        `text-opacity-55 shrink-0 ml-auto pl-1 flex items-center space-x-1`,
         dark('dark:text-opacity-55')
       ),
-      chevron: 'opacity-20 flex-shrink-0 ml-3',
+      chevron: 'opacity-20 shrink-0 ml-3',
       subtitle: 'text-sm',
       text: cls(
         textColor,

--- a/src/react/components/Toast.jsx
+++ b/src/react/components/Toast.jsx
@@ -70,7 +70,7 @@ const Toast = forwardRef((props, ref) => {
         material: 'px-6 py-3.5',
       },
       button: {
-        common: '-my-2 flex-shrink-0 ml-4',
+        common: '-my-2 shrink-0 ml-4',
         ios: '',
         material: '-mr-2',
       },

--- a/src/vue/components/ListInput.vue
+++ b/src/vue/components/ListInput.vue
@@ -299,7 +299,7 @@
               }`
             : '',
           inline: {
-            common: `flex-shrink-10 w-full`,
+            common: `shrink-10 w-full`,
             ios: '-mt-2.5',
             material: `-my-1`,
           },
@@ -318,7 +318,7 @@
         },
         titleWrap: {
           material: `duration-200 ${getLabelColor(true)}`,
-          inline: `w-4/12 flex-shrink-0 mr-2`,
+          inline: `w-4/12 shrink-0 mr-2`,
           notInline: '',
         },
         input: {

--- a/src/vue/components/ListItem.vue
+++ b/src/vue/components/ListItem.vue
@@ -219,7 +219,7 @@
         },
 
         media: {
-          common: `mr-4 flex-shrink-0 ${props.mediaClass}`,
+          common: `mr-4 shrink-0 ${props.mediaClass}`,
           ios: 'py-2',
           material: 'py-3 min-w-10',
         },
@@ -240,7 +240,7 @@
           material: cls(!props.menuListItem && props.titleFontSizeMaterial),
         },
         title: {
-          common: `flex-shrink`,
+          common: `shrink`,
           menuListItem: cls(
             'text-sm',
             props.strongTitle === true || autoStrongTitle.value
@@ -255,10 +255,10 @@
         },
         after: cls(
           textColor.value,
-          `text-opacity-55 flex-shrink-0 ml-auto pl-1 flex items-center space-x-1`,
+          `text-opacity-55 shrink-0 ml-auto pl-1 flex items-center space-x-1`,
           useDarkClasses('dark:text-opacity-55')
         ),
-        chevron: 'opacity-20 flex-shrink-0 ml-3',
+        chevron: 'opacity-20 shrink-0 ml-3',
         subtitle: 'text-sm',
         text: cls(
           textColor.value,

--- a/src/vue/components/Toast.vue
+++ b/src/vue/components/Toast.vue
@@ -65,7 +65,7 @@
           material: 'px-6 py-3.5',
         },
         button: {
-          common: '-my-2 flex-shrink-0 ml-4',
+          common: '-my-2 shrink-0 ml-4',
           ios: '',
           material: '-mr-2',
         },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,7 @@
 const tailwindMobile = require('tailwind-mobile/config');
 
 module.exports = tailwindMobile({
-  mode: 'jit',
-  purge: [
+  content: [
     './kitchen-sink/react/components/*.{js,jsx}',
     './kitchen-sink/react/pages/*.{js,jsx}',
     './kitchen-sink/vue/components/*.{js,jsx,vue}',


### PR DESCRIPTION
Adds support for tailwindcss 3. For tailwind 3 we should also rename `flex-shrink` and `flex-grow` to `shrink` and `grow`.
But these changes won't support tailwindcss 2. Not sure if it's the best strategy. Maybe if we detect `purge` we should return config that supports tailwind 2 and if we get `content` return config for tailwind 3 and also not rename `flex-shrink` and `flex-grow` as it is still supported, although tailwind encourages to rename.
https://tailwindcss.com/docs/upgrade-guide#flex-grow-shrink

Also if you prefer to not support tailwindcss 2 maybe adding tailwind 3 to peer dependencies will make sense.

fixes #27 